### PR TITLE
Add MarshalJSON method to the error validation structs.

### DIFF
--- a/error.go
+++ b/error.go
@@ -40,7 +40,7 @@ func (es SliceErrors) Error() string {
 	return s + "."
 }
 
-// MarshalJSON converts the SliceErrors
+// MarshalJSON converts SliceErrors
 // into a valid JSON.
 func (es SliceErrors) MarshalJSON() ([]byte, error) {
 	errs := map[string]string{}
@@ -72,7 +72,7 @@ func (es Errors) Error() string {
 	return s + "."
 }
 
-// MarshalJSON converts the SliceErrors
+// MarshalJSON converts the Errors
 // into a valid JSON.
 func (es Errors) MarshalJSON() ([]byte, error) {
 	errs := map[string]string{}

--- a/error.go
+++ b/error.go
@@ -5,8 +5,10 @@
 package validation
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 )
 
 type (
@@ -38,6 +40,16 @@ func (es SliceErrors) Error() string {
 	return s + "."
 }
 
+// MarshalJSON converts the SliceErrors
+// into a valid JSON.
+func (es SliceErrors) MarshalJSON() ([]byte, error) {
+	errs := map[string]string{}
+	for key := range es {
+		errs[strconv.Itoa(key)] = es[key].Error()
+	}
+	return json.Marshal(errs)
+}
+
 // Error returns the error string of Errors.
 func (es Errors) Error() string {
 	if len(es) == 0 {
@@ -58,6 +70,16 @@ func (es Errors) Error() string {
 		s += formatError(key, es[key])
 	}
 	return s + "."
+}
+
+// MarshalJSON converts the SliceErrors
+// into a valid JSON.
+func (es Errors) MarshalJSON() ([]byte, error) {
+	errs := map[string]string{}
+	for key := range es {
+		errs[key] = es[key].Error()
+	}
+	return json.Marshal(errs)
 }
 
 func formatError(key interface{}, err error) string {

--- a/error_test.go
+++ b/error_test.go
@@ -28,6 +28,16 @@ func TestErrors_Error(t *testing.T) {
 	assert.Equal(t, "", errs.Error())
 }
 
+func TestError_MarshalMessage(t *testing.T) {
+	errs := Errors{"A": errors.New("A1")}
+	errsJSON, err := errs.MarshalJSON()
+	if err != nil {
+		t.Error("Failed to marshal Errors.")
+	}
+
+	assert.Equal(t, "{\"A\":\"A1\"}", string(errsJSON))
+}
+
 func TestSliceErrors_Error(t *testing.T) {
 	errs := SliceErrors{
 		3: errors.New("B1"),
@@ -43,4 +53,14 @@ func TestSliceErrors_Error(t *testing.T) {
 
 	errs = SliceErrors{}
 	assert.Equal(t, "", errs.Error())
+}
+
+func TestSliceError_MarshalMessage(t *testing.T) {
+	errs := SliceErrors{0: errors.New("A1")}
+	errsJSON, err := errs.MarshalJSON()
+	if err != nil {
+		t.Error("Failed to marshal Errors.")
+	}
+
+	assert.Equal(t, "{\"0\":\"A1\"}", string(errsJSON))
 }


### PR DESCRIPTION
Per https://github.com/golang/go/issues/10748 , marshalling an `error` creates unexpected results.
For example, marshaling `validation.Errors` results in a response like `{"Email": {}, "Name": ""}` where the error message is blank.