### PR TITLE
Adding a new validator for E164 phone format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ Below is the whole list of the rules provided by the `is` package:
 * `VariableWidth`: validates if a string contains both full-width and half-width characters
 * `Base64`: validates if a string is encoded in Base64
 * `DataURI`: validates if a string is a valid base64-encoded data URI
+* `E164`: validates if a string is a valid E164 phone number (+19251232233)
 * `CountryCode2`: validates if a string is a valid ISO3166 Alpha 2 country code
 * `CountryCode3`: validates if a string is a valid ISO3166 Alpha 3 country code
 * `DialString`: validates if a string is a valid dial string that can be passed to Dial()

--- a/is/rules.go
+++ b/is/rules.go
@@ -84,6 +84,8 @@ var (
 	Base64 = validation.NewStringRule(govalidator.IsBase64, "must be encoded in Base64")
 	// DataURI validates if a string is a valid base64-encoded data URI
 	DataURI = validation.NewStringRule(govalidator.IsDataURI, "must be a Base64-encoded data URI")
+	// E164 validates if a string is a valid ISO3166 Alpha 2 country code
+	E164 = validation.NewStringRule(isE164Number, "must be a valid E164 number")
 	// CountryCode2 validates if a string is a valid ISO3166 Alpha 2 country code
 	CountryCode2 = validation.NewStringRule(govalidator.IsISO3166Alpha2, "must be a valid two-letter country code")
 	// CountryCode3 validates if a string is a valid ISO3166 Alpha 3 country code
@@ -132,6 +134,12 @@ func isISBN(value string) bool {
 
 func isDigit(value string) bool {
 	return reDigit.MatchString(value)
+}
+
+func isE164Number(value string) bool {
+	// E164 regex source: https://stackoverflow.com/a/23299989
+	reE164 := regexp.MustCompile(`^\+?[1-9]\d{1,14}$`)
+	return reE164.MatchString(value)
 }
 
 func isSubdomain(value string) bool {

--- a/is/rules_test.go
+++ b/is/rules_test.go
@@ -56,6 +56,7 @@ func TestAll(t *testing.T) {
 		{"JSON", JSON, "[1, 2]", "[1, 2,]", "must be in valid JSON format"},
 		{"ASCII", ASCII, "abc", "ａabc", "must contain ASCII characters only"},
 		{"PrintableASCII", PrintableASCII, "abc", "ａabc", "must contain printable ASCII characters only"},
+		{"E164", E164, "+19251232233", "+00124222333", "must be a valid E164 number"},
 		{"CountryCode2", CountryCode2, "US", "XY", "must be a valid two-letter country code"},
 		{"CountryCode3", CountryCode3, "USA", "XYZ", "must be a valid three-letter country code"},
 		{"DialString", DialString, "localhost.local:1", "localhost.loc:100000", "must be a valid dial string"},


### PR DESCRIPTION
Verified with unit test:

go test is/rules.go is/rules_test.go
│ok      command-line-arguments  0.020s