### PR TITLE
New rule: multipleOf (http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ The following rules are provided in the `validation` package:
 * `NotNil`: checks if a pointer value is not nil. Non-pointer values are considered valid.
 * `NilOrNotEmpty`: checks if a value is a nil pointer or a non-empty value. This differs from `Required` in that it treats a nil pointer as valid.
 * `Skip`: this is a special rule used to indicate that all rules following it should be skipped (including the nested ones).
+* `MultipleOf`: checks if the value is a multiple of the specified range.
 
 The `is` sub-package provides a list of commonly used string validation rules that can be used to check if the format
 of a value satisfies certain requirements. Note that these rules only handle strings and byte slices and if a string

--- a/multipleof.go
+++ b/multipleof.go
@@ -1,0 +1,55 @@
+package validation
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+func MultipleOf(threshold interface{}) *multipleOfRule {
+	return &multipleOfRule{
+		threshold,
+		fmt.Sprintf("must be multiple of %v", threshold),
+	}
+}
+
+type multipleOfRule struct {
+	threshold interface{}
+	message   string
+}
+
+// Error sets the error message for the rule.
+func (r *multipleOfRule) Error(message string) *multipleOfRule {
+	r.message = message
+	return r
+}
+
+
+func (r *multipleOfRule) Validate(value interface{}) error {
+
+	rv := reflect.ValueOf(r.threshold)
+	switch rv.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v, err := ToInt(value)
+		if err != nil {
+			return err
+		}
+		if v%rv.Int() == 0 {
+			return nil
+		}
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		v, err := ToUint(value)
+		if err != nil {
+			return err
+		}
+
+		if v%rv.Uint() == 0 {
+			return nil
+		}
+	default:
+		return fmt.Errorf("type not supported: %v", rv.Type())
+	}
+
+	return errors.New(r.message)
+}

--- a/multipleof_test.go
+++ b/multipleof_test.go
@@ -14,13 +14,16 @@ func TestMultipleof(t *testing.T) {
 	r := MultipleOf(int(10))
 	assert.Equal(t, "must be multiple of 10", r.Validate(int(11)).Error())
 	assert.Equal(t, nil, r.Validate(int(20)))
+	assert.Equal(t, "cannot convert float32 to int64", r.Validate(float32(20)).Error())
+
+	r2 := MultipleOf("some string ....")
+	assert.Equal(t, "type not supported: string", r2.Validate(10).Error())
 
 	r3 := MultipleOf(uint(10))
 	assert.Equal(t, "must be multiple of 10", r3.Validate(uint(11)).Error())
 	assert.Equal(t, nil, r3.Validate(uint(20)))
+	assert.Equal(t, "cannot convert float32 to uint64", r3.Validate(float32(20)).Error())
 
-	r2 := MultipleOf("some string ....")
-	assert.Equal(t, "type not supported: string", r2.Validate(10).Error())
 }
 
 func Test_Multipleof_Error(t *testing.T) {

--- a/multipleof_test.go
+++ b/multipleof_test.go
@@ -1,0 +1,22 @@
+// Copyright 2016 Qiang Xue, Google LLC. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMultipleof(t *testing.T) {
+	r := MultipleOf(10)
+	assert.Equal(t, "must be multiple of 10", r.Validate(11).Error())
+	assert.Equal(t, nil, r.Validate(20))
+}
+
+func Test_Multipleof_Error(t *testing.T) {
+	r := MultipleOf(10)
+	assert.Equal(t, "must be multiple of 10", r.message)
+}

--- a/multipleof_test.go
+++ b/multipleof_test.go
@@ -12,12 +12,12 @@ import (
 
 func TestMultipleof(t *testing.T) {
 	r := MultipleOf(int(10))
-	assert.Equal(t, "must be multiple of 10", r.Validate(11).Error())
-	assert.Equal(t, nil, r.Validate(20))
+	assert.Equal(t, "must be multiple of 10", r.Validate(int(11)).Error())
+	assert.Equal(t, nil, r.Validate(int(20)))
 
 	r3 := MultipleOf(uint(10))
-	assert.Equal(t, "must be multiple of 10", r3.Validate(11).Error())
-	assert.Equal(t, nil, r3.Validate(20))
+	assert.Equal(t, "must be multiple of 10", r3.Validate(uint(11)).Error())
+	assert.Equal(t, nil, r3.Validate(uint(20)))
 
 	r2 := MultipleOf("some string ....")
 	assert.Equal(t, "type not supported: string", r2.Validate(10).Error())

--- a/multipleof_test.go
+++ b/multipleof_test.go
@@ -11,12 +11,22 @@ import (
 )
 
 func TestMultipleof(t *testing.T) {
-	r := MultipleOf(10)
+	r := MultipleOf(int(10))
 	assert.Equal(t, "must be multiple of 10", r.Validate(11).Error())
 	assert.Equal(t, nil, r.Validate(20))
+
+	r3 := MultipleOf(uint(10))
+	assert.Equal(t, "must be multiple of 10", r3.Validate(11).Error())
+	assert.Equal(t, nil, r3.Validate(20))
+
+	r2 := MultipleOf("some string ....")
+	assert.Equal(t, "type not supported: string", r2.Validate(10).Error())
 }
 
 func Test_Multipleof_Error(t *testing.T) {
 	r := MultipleOf(10)
 	assert.Equal(t, "must be multiple of 10", r.message)
+
+	r.Error("some error string ...")
+	assert.Equal(t, "some error string ...", r.message)
 }


### PR DESCRIPTION
Hi team,
Thanks for your great work!
I would suggest you add the MultipleOf method ( http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.2.1 ) to the general list of rules 
It's helpful  for JSON schema validation 