### PR TITLE
Add Each() method for validating iterables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,10 +272,9 @@ fmt.Println(err)
 Sometimes, you may want to skip the invocation of a type's `Validate` method. To do so, simply associate
 a `validation.Skip` rule with the value being validated.
 
-
 ### Maps/Slices/Arrays of Validatables
 
-When validating a map, slice, or array, whose element type implements the `validation.Validatable` interface,
+When validating an iterable (map, slice, or array), whose element type implements the `validation.Validatable` interface,
 the `validation.Validate` method will call the `Validate` method of every non-nil element.
 The validation errors of the elements will be returned as `validation.Errors` which maps the keys of the
 invalid elements to their corresponding validation errors. For example,
@@ -295,6 +294,39 @@ fmt.Println(err)
 When using `validation.ValidateStruct` to validate a struct, the above validation procedure also applies to those struct 
 fields which are map/slices/arrays of validatables. 
 
+#### Each
+
+An other option is to use the `validation.Each` method.
+This method allows you to define the rules for the iterables within a struct.
+
+```go
+type Customer struct {
+    Name      string
+    Emails    []string
+}
+
+func (c Customer) Validate() error {
+    return validation.ValidateStruct(&c,
+        // Name cannot be empty, and the length must be between 5 and 20.
+		validation.Field(&c.Name, validation.Required, validation.Length(5, 20)),
+		// Emails are optional, but if given must be valid.
+		validation.Field(&c.Emails, validation.Each(is.Email)),
+    )
+}
+
+c := Customer{
+    Name:   "Qiang Xue",
+    Emails: []Email{
+        "valid@example.com",
+        "invalid",
+    },
+}
+
+err := c.Validate()
+fmt.Println(err)
+// Output:
+// Emails: (1: must be a valid email address.).
+```
 
 ### Pointers
 
@@ -396,6 +428,7 @@ The following rules are provided in the `validation` package:
 * `NilOrNotEmpty`: checks if a value is a nil pointer or a non-empty value. This differs from `Required` in that it treats a nil pointer as valid.
 * `Skip`: this is a special rule used to indicate that all rules following it should be skipped (including the nested ones).
 * `MultipleOf`: checks if the value is a multiple of the specified range.
+* `Each(rules ...Rule)`: checks the elements within an iterable (map/slice/array) with other rules.
 
 The `is` sub-package provides a list of commonly used string validation rules that can be used to check if the format
 of a value satisfies certain requirements. Note that these rules only handle strings and byte slices and if a string

--- a/each.go
+++ b/each.go
@@ -1,0 +1,79 @@
+// Copyright 2016 Qiang Xue. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package validation
+
+import (
+	"errors"
+	"reflect"
+	"strconv"
+)
+
+// Each returns a validation rule that loops through an iterable (map, slice or array)
+// and validates each value inside with the provided rules.
+// An empty iterable is considered valid. Use the Required rule to make sure the iterable is not empty.
+func Each(rules ...Rule) *EachRule {
+	return &EachRule{
+		rules: rules,
+	}
+}
+
+type EachRule struct {
+	rules []Rule
+}
+
+// Loops through the given iterable and calls the Ozzo Validate() method for each value.
+func (r *EachRule) Validate(value interface{}) error {
+	errs := Errors{}
+
+	v := reflect.ValueOf(value)
+	switch v.Kind() {
+	case reflect.Map:
+		it := v.MapRange()
+		for it.Next() {
+			val := r.getInterface(it.Value())
+			if err := Validate(val, r.rules...); err != nil {
+				errs[r.getString(it.Key())] = err
+			}
+		}
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			val := r.getInterface(v.Index(i))
+			if err := Validate(val, r.rules...); err != nil {
+				errs[strconv.Itoa(i)] = err
+			}
+		}
+	default:
+		return errors.New("must be an iterable (map, slice or array)")
+	}
+
+	if len(errs) > 0 {
+		return errs
+	}
+	return nil
+}
+
+func (r *EachRule) getInterface(value reflect.Value) interface{} {
+	switch value.Kind() {
+	case reflect.Ptr, reflect.Interface:
+		if value.IsNil() {
+			return nil
+		}
+		return value.Elem().Interface()
+	default:
+		return value.Interface()
+	}
+}
+
+func (r *EachRule) getString(value reflect.Value) string {
+	switch value.Kind() {
+	case reflect.Ptr, reflect.Interface:
+		if value.IsNil() {
+			return ""
+		}
+		return value.Elem().String()
+	default:
+		return value.String()
+	}
+}

--- a/each.go
+++ b/each.go
@@ -30,11 +30,10 @@ func (r *EachRule) Validate(value interface{}) error {
 	v := reflect.ValueOf(value)
 	switch v.Kind() {
 	case reflect.Map:
-		it := v.MapRange()
-		for it.Next() {
-			val := r.getInterface(it.Value())
+		for _, k := range v.MapKeys() {
+			val := r.getInterface(v.MapIndex(k))
 			if err := Validate(val, r.rules...); err != nil {
-				errs[r.getString(it.Key())] = err
+				errs[r.getString(k)] = err
 			}
 		}
 	case reflect.Slice, reflect.Array:

--- a/each_test.go
+++ b/each_test.go
@@ -1,0 +1,39 @@
+package validation
+
+import (
+	"testing"
+)
+
+func TestEach(t *testing.T) {
+	var a *int
+	var f = func(v string) string { return v }
+	var c0 chan int
+	c1 := make(chan int)
+
+	tests := []struct {
+		tag   string
+		value interface{}
+		err   string
+	}{
+		{"t1", nil, "must be an iterable (map, slice or array)"},
+		{"t2", map[string]string{}, ""},
+		{"t3", map[string]string{"key1": "value1", "key2": "value2"}, ""},
+		{"t4", map[string]string{"key1": "", "key2": "value2", "key3": ""}, "key1: cannot be blank; key3: cannot be blank."},
+		{"t5", map[string]map[string]string{"key1": {"key1.1": "value1"}, "key2": {"key2.1": "value1"}}, ""},
+		{"t6", map[string]map[string]string{"": nil}, ": cannot be blank."},
+		{"t7", map[interface{}]interface{}{}, ""},
+		{"t8", map[interface{}]interface{}{"key1": struct{ foo string }{"foo"}}, ""},
+		{"t9", map[interface{}]interface{}{nil: "", "": "", "key1": nil}, ": cannot be blank; key1: cannot be blank."},
+		{"t10", []string{"value1", "value2", "value3"}, ""},
+		{"t11", []string{"", "value2", ""}, "0: cannot be blank; 2: cannot be blank."},
+		{"t12", []interface{}{struct{ foo string }{"foo"}}, ""},
+		{"t13", []interface{}{nil, a}, "0: cannot be blank; 1: cannot be blank."},
+		{"t14", []interface{}{c0, c1, f}, "0: cannot be blank."},
+	}
+
+	for _, test := range tests {
+		r := Each(Required)
+		err := r.Validate(test.value)
+		assertError(t, test.err, err, test.tag)
+	}
+}

--- a/struct_test.go
+++ b/struct_test.go
@@ -62,7 +62,7 @@ func TestFindStructField(t *testing.T) {
 
 func TestValidateStruct(t *testing.T) {
 	var m0 *Model1
-	m1 := Model1{A: "abc", B: "xyz", c: "abc", G: "xyz"}
+	m1 := Model1{A: "abc", B: "xyz", c: "abc", G: "xyz", H: []string{"abc", "abc"}, I: map[string]string{"foo": "abc"}}
 	m2 := Model1{E: String123("xyz")}
 	m3 := Model2{}
 	m4 := Model2{M3: Model3{A: "abc"}, Model3: Model3{A: "abc"}}
@@ -82,6 +82,8 @@ func TestValidateStruct(t *testing.T) {
 		{"t2.3", &m1, []*FieldRules{Field(&m1.A, &validateXyz{}), Field(&m1.c, &validateXyz{})}, "A: error xyz; c: error xyz."},
 		{"t2.4", &m1, []*FieldRules{Field(&m1.D, Length(0, 5))}, ""},
 		{"t2.5", &m1, []*FieldRules{Field(&m1.F, Length(0, 5))}, ""},
+		{"t2.6", &m1, []*FieldRules{Field(&m1.H, Each(&validateAbc{})), Field(&m1.I, Each(&validateAbc{}))}, ""},
+		{"t2.6", &m1, []*FieldRules{Field(&m1.H, Each(&validateXyz{})), Field(&m1.I, Each(&validateXyz{}))}, "H: (0: error xyz; 1: error xyz.); I: (foo: error xyz.)."},
 		// non-struct pointer
 		{"t3.1", m1, []*FieldRules{}, ErrStructPointer.Error()},
 		{"t3.2", nil, []*FieldRules{}, ErrStructPointer.Error()},

--- a/validation_test.go
+++ b/validation_test.go
@@ -117,6 +117,8 @@ type Model1 struct {
 	E String123
 	F *String123
 	G string `json:"g"`
+	H []string
+	I map[string]string
 }
 
 type String123 string


### PR DESCRIPTION
I was really missing the ability to validate on arrays or maps, so I've added the Each() method that was mentioned in https://github.com/go-ozzo/ozzo-validation/issues/55.

I've tried to test is as thoroughly as possible.