### PR TITLE
Fix length comparison logic

### DIFF
--- a/length.go
+++ b/length.go
@@ -68,7 +68,7 @@ func (v *LengthRule) Validate(value interface{}) error {
 		return err
 	}
 
-	if v.min > 0 && l < v.min || v.max > 0 && l > v.max {
+	if (v.min > 0 && l < v.min) || (v.max > 0 && l > v.max) {
 		return errors.New(v.message)
 	}
 	return nil

--- a/length_test.go
+++ b/length_test.go
@@ -31,6 +31,7 @@ func TestLength(t *testing.T) {
 		{"t10", 2, 4, sql.NullString{String: "abc", Valid: true}, ""},
 		{"t11", 2, 4, sql.NullString{String: "", Valid: true}, ""},
 		{"t12", 2, 4, &sql.NullString{String: "abc", Valid: true}, ""},
+		{"t13", 1, 0, "", "the length must be no less than 1"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
The comparison logic here doesn't seem to be right; consider the following case: https://play.golang.org/p/Hgsr3P6HAC4