### PR TITLE
Modified the reDomain regex to support upper/lowercase

### DIFF
--- a/is/rules.go
+++ b/is/rules.go
@@ -244,7 +244,7 @@ var (
 	// Domain regex source: https://stackoverflow.com/a/7933253
 	// Slightly modified: Removed 255 max length validation since Go regex does not
 	// support lookarounds. More info: https://stackoverflow.com/a/38935027
-	reDomain = regexp.MustCompile(`^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+(?:[a-z]{1,63}| xn--[a-z0-9]{1,59})$`)
+	reDomain = regexp.MustCompile(`^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-z0-9])?\.)+(?:[a-zA-Z]{1,63}| xn--[a-z0-9]{1,59})$`)
 )
 
 func isISBN(value string) bool {


### PR DESCRIPTION
Modified the reDomain regex to support upper/lowercase

Domains are case insensitive, the `reSubdomain` regex properly supports upper and lowercase however the `reDomain` was lacking this.