### PR TITLE
Fixes LengthRule validation for the case when empty value is required (min=0, max=0)

### DIFF
--- a/length.go
+++ b/length.go
@@ -66,7 +66,7 @@ func (r LengthRule) Validate(value interface{}) error {
 		return err
 	}
 
-	if r.min > 0 && l < r.min || r.max > 0 && l > r.max {
+	if r.min > 0 && l < r.min || r.max > 0 && l > r.max || r.min == 0 && r.max == 0 && l > 0 {
 		return r.err
 	}
 

--- a/length_test.go
+++ b/length_test.go
@@ -33,6 +33,8 @@ func TestLength(t *testing.T) {
 		{"t12", 2, 4, &sql.NullString{String: "abc", Valid: true}, ""},
 		{"t13", 2, 2, "abcdf", "the length must be exactly 2"},
 		{"t14", 2, 2, "ab", ""},
+		{"t15", 0, 0, "", ""},
+		{"t16", 0, 0, "ab", "the value must be empty"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
The error itself is already defined in:
https://github.com/go-ozzo/ozzo-validation/blob/f6ac6c4a9c44e58d830291066150ec95fd9205f3/length.go#L20-L21

but the validation part for min=0, max=0 was missing in:
https://github.com/go-ozzo/ozzo-validation/blob/f6ac6c4a9c44e58d830291066150ec95fd9205f3/length.go#L69-L71

Added with:
```golang
if r.min > 0 && l < r.min || r.max > 0 && l > r.max || r.min == 0 && r.max == 0 && l > 0 {
	return r.err
}
```