### PR TITLE
Fallback to field name for ignored JSON fields

### DIFF
--- a/struct.go
+++ b/struct.go
@@ -164,7 +164,7 @@ func findStructField(structValue reflect.Value, fieldValue reflect.Value) *refle
 
 // getErrorFieldName returns the name that should be used to represent the validation error of a struct field.
 func getErrorFieldName(f *reflect.StructField) string {
-	if tag := f.Tag.Get(ErrorTag); tag != "" {
+	if tag := f.Tag.Get(ErrorTag); tag != "" && tag != "-" {
 		if cps := strings.SplitN(tag, ",", 2); cps[0] != "" {
 			return cps[0]
 		}

--- a/struct_test.go
+++ b/struct_test.go
@@ -19,8 +19,10 @@ type Struct1 struct {
 	Field4 [4]int
 	field5 int
 	Struct2
-	S1 *Struct2
-	S2 Struct2
+	S1               *Struct2
+	S2               Struct2
+	JSONField        int `json:"some_json_field"`
+	JSONIgnoredField int `json:"-"`
 }
 
 type Struct2 struct {
@@ -184,4 +186,20 @@ func TestValidateStructWithContext(t *testing.T) {
 	if assert.NotNil(t, err) {
 		assert.Equal(t, "Value: the length must be between 5 and 10.", err.Error())
 	}
+}
+func Test_getErrorFieldName(t *testing.T) {
+	var s1 Struct1
+	v1 := reflect.ValueOf(&s1).Elem()
+
+	sf1 := findStructField(v1, reflect.ValueOf(&s1.Field1))
+	assert.NotNil(t, sf1)
+	assert.Equal(t, "Field1", getErrorFieldName(sf1))
+
+	jsonField := findStructField(v1, reflect.ValueOf(&s1.JSONField))
+	assert.NotNil(t, jsonField)
+	assert.Equal(t, "some_json_field", getErrorFieldName(jsonField))
+
+	jsonIgnoredField := findStructField(v1, reflect.ValueOf(&s1.JSONIgnoredField))
+	assert.NotNil(t, jsonIgnoredField)
+	assert.Equal(t, "JSONIgnoredField", getErrorFieldName(jsonIgnoredField))
 }


### PR DESCRIPTION
This change will make field names linking to an ignored JSON field fallback to the go field name.

Otherwise, we would see `-` in the generated error messages.