### PR TITLE
Validate untyped maps similar to structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ If a rule fails, an error is recorded for that field, and the validation will co
 
 ### Validating a Map
 
-Sometimes you might need to work with dynamic data stored in maps rather than a typed model. You can use `validation.ValidateMap()`
+Sometimes you might need to work with dynamic data stored in maps rather than a typed model. You can use `validation.Map()`
 in this situation. A single map can have rules for multiple keys, and a key can be associated with multiple 
 rules. For example,
 
@@ -142,29 +142,31 @@ c := map[string]interface{}{
 	},
 }
 
-err := validation.ValidateMap(c,
-	// Name cannot be empty, and the length must be between 5 and 20.
-	validation.Key("Name", validation.Required, validation.Length(5, 20)),
-	// Email cannot be empty and should be in a valid email format.
-	validation.Key("Email", validation.Required, is.Email),
-	// Validate Address using its own validation rules
-	validation.Key("Address", validation.Map(
-		// Street cannot be empty, and the length must between 5 and 50
-		validation.Key("Street", validation.Required, validation.Length(5, 50)),
-		// City cannot be empty, and the length must between 5 and 50
-		validation.Key("City", validation.Required, validation.Length(5, 50)),
-		// State cannot be empty, and must be a string consisting of two letters in upper case
-		validation.Key("State", validation.Required, validation.Match(regexp.MustCompile("^[A-Z]{2}$"))),
-		// State cannot be empty, and must be a string consisting of five digits
-		validation.Key("Zip", validation.Required, validation.Match(regexp.MustCompile("^[0-9]{5}$"))),
-	)),
+err := validation.Validate(c,
+	validation.Map(
+		// Name cannot be empty, and the length must be between 5 and 20.
+		validation.Key("Name", validation.Required, validation.Length(5, 20)),
+		// Email cannot be empty and should be in a valid email format.
+		validation.Key("Email", validation.Required, is.Email),
+		// Validate Address using its own validation rules
+		validation.Key("Address", validation.Map(
+			// Street cannot be empty, and the length must between 5 and 50
+			validation.Key("Street", validation.Required, validation.Length(5, 50)),
+			// City cannot be empty, and the length must between 5 and 50
+			validation.Key("City", validation.Required, validation.Length(5, 50)),
+			// State cannot be empty, and must be a string consisting of two letters in upper case
+			validation.Key("State", validation.Required, validation.Match(regexp.MustCompile("^[A-Z]{2}$"))),
+			// State cannot be empty, and must be a string consisting of five digits
+			validation.Key("Zip", validation.Required, validation.Match(regexp.MustCompile("^[0-9]{5}$"))),
+		)),
+	),
 )
 fmt.Println(err)
 // Output:
 // Address: (State: must be in a valid format; Street: the length must be between 5 and 50.); Email: must be a valid email address.
 ```
 
-When the map validation is performed, the keys are validated in the order they are specified in `ValidateMap`. 
+When the map validation is performed, the keys are validated in the order they are specified in `Map`. 
 And when each key is validated, its rules are also evaluated in the order they are associated with the key.
 If a rule fails, an error is recorded for that key, and the validation will continue with the next key.
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,51 @@ And when each field is validated, its rules are also evaluated in the order they
 If a rule fails, an error is recorded for that field, and the validation will continue with the next field.
 
 
+### Validating a Map
+
+Sometimes you might need to work with dynamic data stored in maps rather than a typed model. You can use `validation.ValidateMap()`
+in this situation. A single map can have rules for multiple keys, and a key can be associated with multiple 
+rules. For example,
+
+```go
+c := map[string]interface{}{
+	"Name":  "Qiang Xue",
+	"Email": "q",
+	"Address": map[string]interface{}{
+		"Street": "123",
+		"City":   "Unknown",
+		"State":  "Virginia",
+		"Zip":    "12345",
+	},
+}
+
+err := validation.ValidateMap(c,
+	// Name cannot be empty, and the length must be between 5 and 20.
+	validation.Key("Name", validation.Required, validation.Length(5, 20)),
+	// Email cannot be empty and should be in a valid email format.
+	validation.Key("Email", validation.Required, is.Email),
+	// Validate Address using its own validation rules
+	validation.Key("Address", validation.Map(
+		// Street cannot be empty, and the length must between 5 and 50
+		validation.Key("Street", validation.Required, validation.Length(5, 50)),
+		// City cannot be empty, and the length must between 5 and 50
+		validation.Key("City", validation.Required, validation.Length(5, 50)),
+		// State cannot be empty, and must be a string consisting of two letters in upper case
+		validation.Key("State", validation.Required, validation.Match(regexp.MustCompile("^[A-Z]{2}$"))),
+		// State cannot be empty, and must be a string consisting of five digits
+		validation.Key("Zip", validation.Required, validation.Match(regexp.MustCompile("^[0-9]{5}$"))),
+	)),
+)
+fmt.Println(err)
+// Output:
+// Address: (State: must be in a valid format; Street: the length must be between 5 and 50.); Email: must be a valid email address.
+```
+
+When the map validation is performed, the keys are validated in the order they are specified in `ValidateMap`. 
+And when each key is validated, its rules are also evaluated in the order they are associated with the key.
+If a rule fails, an error is recorded for that key, and the validation will continue with the next key.
+
+
 ### Validation Errors
 
 The `validation.ValidateStruct` method returns validation errors found in struct fields in terms of `validation.Errors` 

--- a/example_test.go
+++ b/example_test.go
@@ -167,22 +167,24 @@ func Example_seven() {
 		},
 	}
 
-	err := validation.ValidateMap(c,
-		// Name cannot be empty, and the length must be between 5 and 20.
-		validation.Key("Name", validation.Required, validation.Length(5, 20)),
-		// Email cannot be empty and should be in a valid email format.
-		validation.Key("Email", validation.Required, is.Email),
-		// Validate Address using its own validation rules
-		validation.Key("Address", validation.Map(
-			// Street cannot be empty, and the length must between 5 and 50
-			validation.Key("Street", validation.Required, validation.Length(5, 50)),
-			// City cannot be empty, and the length must between 5 and 50
-			validation.Key("City", validation.Required, validation.Length(5, 50)),
-			// State cannot be empty, and must be a string consisting of two letters in upper case
-			validation.Key("State", validation.Required, validation.Match(regexp.MustCompile("^[A-Z]{2}$"))),
-			// State cannot be empty, and must be a string consisting of five digits
-			validation.Key("Zip", validation.Required, validation.Match(regexp.MustCompile("^[0-9]{5}$"))),
-		)),
+	err := validation.Validate(c,
+		validation.Map(
+			// Name cannot be empty, and the length must be between 5 and 20.
+			validation.Key("Name", validation.Required, validation.Length(5, 20)),
+			// Email cannot be empty and should be in a valid email format.
+			validation.Key("Email", validation.Required, is.Email),
+			// Validate Address using its own validation rules
+			validation.Key("Address", validation.Map(
+				// Street cannot be empty, and the length must between 5 and 50
+				validation.Key("Street", validation.Required, validation.Length(5, 50)),
+				// City cannot be empty, and the length must between 5 and 50
+				validation.Key("City", validation.Required, validation.Length(5, 50)),
+				// State cannot be empty, and must be a string consisting of two letters in upper case
+				validation.Key("State", validation.Required, validation.Match(regexp.MustCompile("^[A-Z]{2}$"))),
+				// State cannot be empty, and must be a string consisting of five digits
+				validation.Key("Zip", validation.Required, validation.Match(regexp.MustCompile("^[0-9]{5}$"))),
+			)),
+		),
 	)
 	fmt.Println(err)
 	// Output:

--- a/example_test.go
+++ b/example_test.go
@@ -154,3 +154,37 @@ func Example_six() {
 	// unexpected value
 	// <nil>
 }
+
+func Example_seven() {
+	c := map[string]interface{}{
+		"Name":  "Qiang Xue",
+		"Email": "q",
+		"Address": map[string]interface{}{
+			"Street": "123",
+			"City":   "Unknown",
+			"State":  "Virginia",
+			"Zip":    "12345",
+		},
+	}
+
+	err := validation.ValidateMap(c,
+		// Name cannot be empty, and the length must be between 5 and 20.
+		validation.Key("Name", validation.Required, validation.Length(5, 20)),
+		// Email cannot be empty and should be in a valid email format.
+		validation.Key("Email", validation.Required, is.Email),
+		// Validate Address using its own validation rules
+		validation.Key("Address", validation.Map(
+			// Street cannot be empty, and the length must between 5 and 50
+			validation.Key("Street", validation.Required, validation.Length(5, 50)),
+			// City cannot be empty, and the length must between 5 and 50
+			validation.Key("City", validation.Required, validation.Length(5, 50)),
+			// State cannot be empty, and must be a string consisting of two letters in upper case
+			validation.Key("State", validation.Required, validation.Match(regexp.MustCompile("^[A-Z]{2}$"))),
+			// State cannot be empty, and must be a string consisting of five digits
+			validation.Key("Zip", validation.Required, validation.Match(regexp.MustCompile("^[0-9]{5}$"))),
+		)),
+	)
+	fmt.Println(err)
+	// Output:
+	// Address: (State: must be in a valid format; Street: the length must be between 5 and 50.); Email: must be a valid email address.
+}

--- a/map.go
+++ b/map.go
@@ -1,0 +1,138 @@
+package validation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+var (
+	// ErrNotMap is the error that the value being validated is not a map.
+	ErrNotMap = errors.New("only a map can be validated")
+)
+
+type (
+	// ErrKeyWrongType is the error that a key is the wrong type.
+	ErrKeyWrongType string
+
+	// ErrKeyNotFound is the error that a key cannot be found in the map.
+	ErrKeyNotFound string
+
+	// KeyRules represents a rule set associated with a map key.
+	KeyRules struct {
+		key   interface{}
+		rules []Rule
+	}
+)
+
+// Error returns the error string of ErrKeyWrongType.
+func (e ErrKeyWrongType) Error() string {
+	return fmt.Sprintf("key %q is the wrong type", string(e))
+}
+
+// Error returns the error string of ErrKeyNotFound.
+func (e ErrKeyNotFound) Error() string {
+	return fmt.Sprintf("key %q cannot be found in the map", string(e))
+}
+
+// ValidateMap validates a map by checking the specified map keys against the corresponding validation rules.
+// Note that if the value is nil, it is considered valid.
+// Use Key() to specify map keys that need to be validated. Each Key() call specifies a single key. A key can
+// be associated with multiple rules.
+// For example,
+//
+//    value := map[string]string{
+//        "Name":  "name",
+//        "Value": "demo",
+//    }
+//    err := validation.ValidateMap(value,
+//         validation.Key("Name", validation.Required),
+//         validation.Key("Value", validation.Required, validation.Length(5, 10)),
+//    )
+//    fmt.Println(err)
+//    // Value: the length must be between 5 and 10.
+//
+// An error will be returned if validation fails.
+func ValidateMap(m interface{}, keys ...*KeyRules) error {
+	return ValidateMapWithContext(nil, m, keys...)
+}
+
+// ValidateMapWithContext validates a map with the given context.
+// The only difference between ValidateMapWithContext and ValidateMap is that the former will
+// validate map keys with the provided context.
+// Please refer to ValidateMap for the detailed instructions on how to use this function.
+func ValidateMapWithContext(ctx context.Context, m interface{}, keys ...*KeyRules) error {
+	value := reflect.ValueOf(m)
+	if value.Kind() == reflect.Ptr {
+		value = value.Elem()
+	}
+	if value.Kind() != reflect.Map {
+		// must be a map
+		return NewInternalError(ErrNotMap)
+	}
+	if value.IsNil() {
+		// treat a nil map as valid
+		return nil
+	}
+
+	errs := Errors{}
+	kt := value.Type().Key()
+
+	for _, kr := range keys {
+		kv := reflect.ValueOf(kr.key)
+		if !kt.AssignableTo(kv.Type()) {
+			return NewInternalError(ErrKeyWrongType(getErrorKeyName(kr.key)))
+		}
+		vv := value.MapIndex(kv)
+		if !vv.IsValid() {
+			return NewInternalError(ErrKeyNotFound(getErrorKeyName(kr.key)))
+		}
+		var err error
+		if ctx == nil {
+			err = Validate(vv.Interface(), kr.rules...)
+		} else {
+			err = ValidateWithContext(ctx, vv.Interface(), kr.rules...)
+		}
+		if err != nil {
+			if ie, ok := err.(InternalError); ok && ie.InternalError() != nil {
+				return err
+			}
+			errs[getErrorKeyName(kr.key)] = err
+		}
+	}
+
+	if len(errs) > 0 {
+		return errs
+	}
+	return nil
+}
+
+// Key specifies a map key and the corresponding validation rules.
+func Key(key interface{}, rules ...Rule) *KeyRules {
+	return &KeyRules{
+		key:   key,
+		rules: rules,
+	}
+}
+
+// getErrorKeyName returns the name that should be used to represent the validation error of a map key.
+func getErrorKeyName(key interface{}) string {
+	return fmt.Sprintf("%v", key)
+}
+
+type MapRule struct {
+	keys []*KeyRules
+}
+
+func (r *MapRule) Validate(value interface{}) error {
+	return ValidateMap(value, r.keys...)
+}
+
+func (r *MapRule) ValidateWithContext(ctx context.Context, value interface{}) error {
+	return ValidateMapWithContext(ctx, value, r.keys...)
+}
+
+func Map(keys ...*KeyRules) *MapRule {
+	return &MapRule{keys}
+}

--- a/map_test.go
+++ b/map_test.go
@@ -1,0 +1,118 @@
+package validation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateMap(t *testing.T) {
+	var m0 map[string]interface{}
+	m1 := map[string]interface{}{"A": "abc", "B": "xyz", "c": "abc", "D": (*string)(nil), "F": (*String123)(nil), "H": []string{"abc", "abc"}, "I": map[string]string{"foo": "abc"}}
+	m2 := map[string]interface{}{"E": String123("xyz"), "F": (*String123)(nil)}
+	m3 := map[string]interface{}{"M3": Model3{}}
+	m4 := map[string]interface{}{"M3": Model3{A: "abc"}}
+	m5 := map[string]interface{}{"A": "internal", "B": ""}
+	m6 := map[int]string{11: "abc", 22: "xyz"}
+	tests := []struct {
+		tag   string
+		model interface{}
+		rules []*KeyRules
+		err   string
+	}{
+		// empty rules
+		{"t1.1", m1, []*KeyRules{}, ""},
+		{"t1.2", m1, []*KeyRules{Key("A"), Key("B")}, ""},
+		// normal rules
+		{"t2.1", m1, []*KeyRules{Key("A", &validateAbc{}), Key("B", &validateXyz{})}, ""},
+		{"t2.2", m1, []*KeyRules{Key("A", &validateXyz{}), Key("B", &validateAbc{})}, "A: error xyz; B: error abc."},
+		{"t2.3", m1, []*KeyRules{Key("A", &validateXyz{}), Key("c", &validateXyz{})}, "A: error xyz; c: error xyz."},
+		{"t2.4", m1, []*KeyRules{Key("D", Length(0, 5))}, ""},
+		{"t2.5", m1, []*KeyRules{Key("F", Length(0, 5))}, ""},
+		{"t2.6", m1, []*KeyRules{Key("H", Each(&validateAbc{})), Key("I", Each(&validateAbc{}))}, ""},
+		{"t2.7", m1, []*KeyRules{Key("H", Each(&validateXyz{})), Key("I", Each(&validateXyz{}))}, "H: (0: error xyz; 1: error xyz.); I: (foo: error xyz.)."},
+		{"t2.8", m1, []*KeyRules{Key("I", Map(Key("foo", &validateAbc{})))}, ""},
+		{"t2.9", m1, []*KeyRules{Key("I", Map(Key("foo", &validateXyz{})))}, "I: (foo: error xyz.)."},
+		// non-map value
+		{"t3.1", &m1, []*KeyRules{}, ""},
+		{"t3.2", nil, []*KeyRules{}, ErrNotMap.Error()},
+		{"t3.3", m0, []*KeyRules{}, ""},
+		{"t3.4", &m0, []*KeyRules{}, ""},
+		{"t3.5", 123, []*KeyRules{}, ErrNotMap.Error()},
+		// invalid key spec
+		{"t4.1", m1, []*KeyRules{Key(123)}, ErrKeyWrongType("123").Error()},
+		{"t4.2", m1, []*KeyRules{Key("X")}, ErrKeyNotFound("X").Error()},
+		// non-string keys
+		{"t5.1", m6, []*KeyRules{Key(11, &validateAbc{}), Key(22, &validateXyz{})}, ""},
+		{"t5.2", m6, []*KeyRules{Key(11, &validateXyz{}), Key(22, &validateAbc{})}, "11: error xyz; 22: error abc."},
+		// validatable value
+		{"t6.1", m2, []*KeyRules{Key("E")}, "E: error 123."},
+		{"t6.2", m2, []*KeyRules{Key("E", Skip)}, ""},
+		{"t6.3", m2, []*KeyRules{Key("E", Skip.When(true))}, ""},
+		{"t6.4", m2, []*KeyRules{Key("E", Skip.When(false))}, "E: error 123."},
+		// Required, NotNil
+		{"t7.1", m2, []*KeyRules{Key("F", Required)}, "F: cannot be blank."},
+		{"t7.2", m2, []*KeyRules{Key("F", NotNil)}, "F: is required."},
+		{"t7.3", m2, []*KeyRules{Key("F", Skip, Required)}, ""},
+		{"t7.4", m2, []*KeyRules{Key("F", Skip, NotNil)}, ""},
+		{"t7.5", m2, []*KeyRules{Key("F", Skip.When(true), Required)}, ""},
+		{"t7.6", m2, []*KeyRules{Key("F", Skip.When(true), NotNil)}, ""},
+		{"t7.7", m2, []*KeyRules{Key("F", Skip.When(false), Required)}, "F: cannot be blank."},
+		{"t7.8", m2, []*KeyRules{Key("F", Skip.When(false), NotNil)}, "F: is required."},
+		// validatable structs
+		{"t8.1", m3, []*KeyRules{Key("M3", Skip)}, ""},
+		{"t8.2", m3, []*KeyRules{Key("M3")}, "M3: (A: error abc.)."},
+		{"t8.3", m4, []*KeyRules{Key("M3")}, ""},
+		// internal error
+		{"t9.1", m5, []*KeyRules{Key("A", &validateAbc{}), Key("B", Required), Key("A", &validateInternalError{})}, "error internal"},
+	}
+	for _, test := range tests {
+		err1 := ValidateMap(test.model, test.rules...)
+		err2 := ValidateMapWithContext(context.Background(), test.model, test.rules...)
+		assertError(t, test.err, err1, test.tag)
+		assertError(t, test.err, err2, test.tag)
+	}
+
+	a := map[string]interface{}{"Name": "name", "Value": "demo"}
+	err := ValidateMap(a,
+		Key("Name", Required),
+		Key("Value", Required, Length(5, 10)),
+	)
+	assert.EqualError(t, err, "Value: the length must be between 5 and 10.")
+}
+
+func TestValidateMapWithContext(t *testing.T) {
+	m1 := map[string]interface{}{"A": "abc", "B": "xyz", "c": "abc", "g": "xyz"}
+	m2 := map[string]interface{}{"A": "internal", "B": ""}
+	tests := []struct {
+		tag   string
+		model interface{}
+		rules []*KeyRules
+		err   string
+	}{
+		// normal rules
+		{"t1.1", m1, []*KeyRules{Key("A", &validateContextAbc{}), Key("B", &validateContextXyz{})}, ""},
+		{"t1.2", m1, []*KeyRules{Key("A", &validateContextXyz{}), Key("B", &validateContextAbc{})}, "A: error xyz; B: error abc."},
+		{"t1.3", m1, []*KeyRules{Key("A", &validateContextXyz{}), Key("c", &validateContextXyz{})}, "A: error xyz; c: error xyz."},
+		{"t1.4", m1, []*KeyRules{Key("g", &validateContextAbc{})}, "g: error abc."},
+		// skip rule
+		{"t2.1", m1, []*KeyRules{Key("g", Skip, &validateContextAbc{})}, ""},
+		{"t2.2", m1, []*KeyRules{Key("g", &validateContextAbc{}, Skip)}, "g: error abc."},
+		// internal error
+		{"t3.1", m2, []*KeyRules{Key("A", &validateContextAbc{}), Key("B", Required), Key("A", &validateInternalError{})}, "error internal"},
+	}
+	for _, test := range tests {
+		err := ValidateMapWithContext(context.Background(), test.model, test.rules...)
+		assertError(t, test.err, err, test.tag)
+	}
+
+	a := map[string]interface{}{"Name": "name", "Value": "demo"}
+	err := ValidateMapWithContext(context.Background(), a,
+		Key("Name", Required),
+		Key("Value", Required, Length(5, 10)),
+	)
+	if assert.NotNil(t, err) {
+		assert.Equal(t, "Value: the length must be between 5 and 10.", err.Error())
+	}
+}

--- a/map_test.go
+++ b/map_test.go
@@ -43,6 +43,7 @@ func TestMap(t *testing.T) {
 		// invalid key spec
 		{"t4.1", m1, []*KeyRules{Key(123)}, "123: key not the correct type."},
 		{"t4.2", m1, []*KeyRules{Key("X")}, "X: required key is missing."},
+		{"t4.3", m1, []*KeyRules{Key("X").Optional()}, ""},
 		// non-string keys
 		{"t5.1", m6, []*KeyRules{Key(11, &validateAbc{}), Key(22, &validateXyz{})}, ""},
 		{"t5.2", m6, []*KeyRules{Key(11, &validateXyz{}), Key(22, &validateAbc{})}, "11: error xyz; 22: error abc."},


### PR DESCRIPTION
As discussed in #126, I decided to give it a shot including @dlpetrie's suggestion for maps within structs (and visa versa).

This PR also includes a non-breaking change to allow non-pointer structs in `ValidateStruct` plus some minor linting tweaks. I can split these into separate PRs if preferred.