### PR TITLE
add int rule

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.13
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496
+	github.com/brianvoe/gofakeit/v5 v5.11.2
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
+github.com/brianvoe/gofakeit/v5 v5.11.2 h1:Ny5Nsf4z2023ZvYP8ujW8p5B1t5sxhdFaQ/0IYXbeSA=
+github.com/brianvoe/gofakeit/v5 v5.11.2/go.mod h1:/ZENnKqX+XrN8SORLe/fu5lZDIo1tuPncWuRD+eyhSI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/int_rule.go
+++ b/int_rule.go
@@ -1,0 +1,58 @@
+package validation
+
+// modeled after string valdiator
+
+type intValidator func(int64) bool
+
+// int rule checks an int variable using a specified intValidator
+type IntRule struct {
+	validate intValidator
+	err      Error
+}
+
+// NewIntRule creates a new validation rule using a function that takes a int value and returns a bool.
+// The rule returned will use the function to check if a given int is valid or not.
+func NewIntRule(validator intValidator, message string) IntRule {
+	return IntRule{
+		validate: validator,
+		err:      NewError("", message),
+	}
+}
+
+// NewIntRuleWithError creates a new validation rule using a function that takes a int value and returns a bool.
+func NewIntRuleWithError(validator intValidator, err Error) IntRule {
+	return IntRule{
+		validate: validator,
+		err:      err,
+	}
+}
+
+// Error sets the error message for the rule.
+func (i IntRule) Error(message string) IntRule {
+	i.err = i.err.SetMessage(message)
+	return i
+}
+
+// ErrorObject sets the error struct for the rule.
+func (i IntRule) ErrorObject(err Error) IntRule {
+	i.err = err
+	return i
+}
+
+func (i IntRule) Validate(value interface{}) error {
+	value, isNil := Indirect(value)
+	if isNil {
+		return nil
+	}
+
+	intVal, err := ToInt(value)
+	if err != nil {
+		return err
+	}
+
+	if i.validate(intVal) {
+		return nil
+	}
+
+	return i.err
+}

--- a/int_rule_test.go
+++ b/int_rule_test.go
@@ -1,0 +1,51 @@
+package validation
+
+import (
+	"github.com/brianvoe/gofakeit/v5"
+	"testing"
+)
+
+// mock true return in rule
+func testIntValidatorTrue(int int64) bool {
+	return true
+}
+
+// mock false return in rule
+func testIntValidatorFalse(int int64) bool {
+	return false
+}
+
+var errShouldBeTrue = NewError("test_err_should_be_true", "error should return true")
+
+func TestNewIntRule(t *testing.T) {
+	// test raw int rule false
+	rule := NewIntRule(testIntValidatorFalse, "this is a test, this should be false")
+	err := rule.Validate(gofakeit.Int64())
+	if err == nil {
+		t.Error("expected error when using testIntValidatorFalse")
+	}
+
+	// test raw int rule true
+	rule = NewIntRule(testIntValidatorTrue, "this is a test, this should be false")
+	rule.ErrorObject(errShouldBeTrue)
+	rule.Error("this is a test, this should be false")
+	err = rule.Validate(gofakeit.Int64())
+	if err != nil {
+		t.Error("expected error when using testIntValidatorTrue")
+	}
+
+	// test intrule with error
+	rule = NewIntRuleWithError(testIntValidatorFalse, errShouldBeTrue)
+	err = rule.Validate(gofakeit.Int64())
+	if err == nil {
+		t.Error("expected error")
+	}
+
+	// test wrong type
+	rule = NewIntRuleWithError(testIntValidatorTrue, errShouldBeTrue)
+	err = rule.Validate(gofakeit.Name())
+	if err == nil {
+		t.Error("wrong type should result in err")
+	}
+
+}


### PR DESCRIPTION
As per some pr's that have been sitting around for a while (e.g. #93) and uncertainty as to how this framework is used in the larger [ozzo](https://github.com/go-ozzo?type=source) project I wanted to make sure that this repo was still open before I spend too much time on this.

I've taken the [`int_rule`](https://github.com/xplorfin/ozzo-validators/blob/master/rules/int_rule.go) functionality (and corresponding [test case](https://github.com/xplorfin/ozzo-validators/blob/master/rules/int_rule_test.go)) I added in [ozzo-validators](https://github.com/xplorfin/ozzo-validators) and added it here. This allows you to validate structs on non-string fields.

For instance, [IsValidPort](https://github.com/xplorfin/ozzo-validators/blob/b307e70b02436ec9ae91b69742b14db5edb65d60/custom_validators_test.go#L31) and [IsAvailablePort](https://github.com/xplorfin/ozzo-validators/blob/b307e70b02436ec9ae91b69742b14db5edb65d60/custom_validators_test.go#L32) here validates on an int rather than a string.

Here's what that looks like in the context of a struct validation:

![image](https://user-images.githubusercontent.com/6392429/105642588-95e6dc80-5e58-11eb-871c-ed615f4cabe1.png)
