### PR TITLE
Add function to get the value of the json tag for a field in a struct

### DIFF
--- a/struct.go
+++ b/struct.go
@@ -128,8 +128,8 @@ func Field(fieldPtr interface{}, rules ...Rule) *FieldRules {
 	}
 }
 
-// FindStructFieldJSONName gets the value of the `json` tag for the given field in the given struct
-func FindStructFieldJSONName(structPtr interface{}, fieldPtr interface{}) (string, error) {
+// ErrorFieldName gets the value of the `json` tag for the given field in the given struct
+func ErrorFieldName(structPtr interface{}, fieldPtr interface{}) (string, error) {
 	value := reflect.ValueOf(structPtr)
 	if value.Kind() != reflect.Ptr || !value.IsNil() && value.Elem().Kind() != reflect.Struct {
 		// must be a pointer to a struct

--- a/struct.go
+++ b/struct.go
@@ -128,6 +128,31 @@ func Field(fieldPtr interface{}, rules ...Rule) *FieldRules {
 	}
 }
 
+// FindStructFieldJSONName gets the value of the `json` tag for the given field in the given struct
+func FindStructFieldJSONName(structPtr interface{}, fieldPtr interface{}) (string, error) {
+	value := reflect.ValueOf(structPtr)
+	if value.Kind() != reflect.Ptr || !value.IsNil() && value.Elem().Kind() != reflect.Struct {
+		// must be a pointer to a struct
+		return "", NewInternalError(ErrStructPointer)
+	}
+	if value.IsNil() {
+		// treat a nil struct pointer as valid
+		return "", nil
+	}
+	value = value.Elem()
+
+	fv := reflect.ValueOf(fieldPtr)
+	if fv.Kind() != reflect.Ptr {
+		// must be a pointer to a field
+		return "", NewInternalError(ErrFieldPointer(0))
+	}
+	ft := findStructField(value, fv)
+	if ft == nil {
+		return "", NewInternalError(ErrFieldNotFound(0))
+	}
+	return getErrorFieldName(ft), nil
+}
+
 // findStructField looks for a field in the given struct.
 // The field being looked for should be a pointer to the actual struct field.
 // If found, the field info will be returned. Otherwise, nil will be returned.

--- a/struct_test.go
+++ b/struct_test.go
@@ -290,11 +290,11 @@ func TestFindStructFieldJSONName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.initFn(&tt)
-			got, err := FindStructFieldJSONName(tt.args.structPtr, tt.args.fieldPtr)
-			if !tt.wantErr(t, err, fmt.Sprintf("FindStructFieldJSONName(%v, %v)", tt.args.structPtr, tt.args.fieldPtr)) {
+			got, err := ErrorFieldName(tt.args.structPtr, tt.args.fieldPtr)
+			if !tt.wantErr(t, err, fmt.Sprintf("ErrorFieldName(%v, %v)", tt.args.structPtr, tt.args.fieldPtr)) {
 				return
 			}
-			assert.Equalf(t, tt.want, got, "FindStructFieldJSONName(%v, %v)", tt.args.structPtr, tt.args.fieldPtr)
+			assert.Equalf(t, tt.want, got, "ErrorFieldName(%v, %v)", tt.args.structPtr, tt.args.fieldPtr)
 		})
 	}
 }

--- a/struct_test.go
+++ b/struct_test.go
@@ -233,7 +233,7 @@ func TestFindStructFieldJSONName(t *testing.T) {
 			},
 		},
 		{
-			name:    "nil struct pointer succeeds with bo error and empty JSON name",
+			name:    "nil struct pointer succeeds with no error and empty JSON name",
 			args:    args{},
 			want:    "",
 			wantErr: assert.NoError,


### PR DESCRIPTION
This enables the use-case where a mutual exclusion validation rule needs to know the name of a field other than the field currently being validated