### PR TITLE
customization of GetErrorFieldName

### DIFF
--- a/struct.go
+++ b/struct.go
@@ -16,7 +16,7 @@ var (
 	// ErrStructPointer is the error that a struct being validated is not specified as a pointer.
 	ErrStructPointer = errors.New("only a pointer to a struct can be validated")
 	// GetErrorFieldName is used to get a field name, overriding the default
-	GetErrorFieldName GetErrorFieldNameFunc = getErrorFieldName
+	GetErrorFieldName func(f *reflect.StructField) string = getErrorFieldName
 )
 
 type (
@@ -31,9 +31,6 @@ type (
 		fieldPtr interface{}
 		rules    []Rule
 	}
-
-	// GetErrorFieldNameFunc is a function that retrieves the desired field name from  a struct field.
-	GetErrorFieldNameFunc func(f *reflect.StructField) string
 )
 
 // Error returns the error string of ErrFieldPointer.

--- a/struct.go
+++ b/struct.go
@@ -15,6 +15,8 @@ import (
 var (
 	// ErrStructPointer is the error that a struct being validated is not specified as a pointer.
 	ErrStructPointer = errors.New("only a pointer to a struct can be validated")
+	// GetErrorFieldName is used to get a field name, overriding the default
+	GetErrorFieldName GetErrorFieldNameFunc = getErrorFieldName
 )
 
 type (
@@ -29,6 +31,9 @@ type (
 		fieldPtr interface{}
 		rules    []Rule
 	}
+
+	// GetErrorFieldNameFunc is a function that retrieves the desired field name from  a struct field.
+	GetErrorFieldNameFunc func(f *reflect.StructField) string
 )
 
 // Error returns the error string of ErrFieldPointer.
@@ -47,16 +52,16 @@ func (e ErrFieldNotFound) Error() string {
 // should be specified as a pointer to the field. A field can be associated with multiple rules.
 // For example,
 //
-//    value := struct {
-//        Name  string
-//        Value string
-//    }{"name", "demo"}
-//    err := validation.ValidateStruct(&value,
-//        validation.Field(&a.Name, validation.Required),
-//        validation.Field(&a.Value, validation.Required, validation.Length(5, 10)),
-//    )
-//    fmt.Println(err)
-//    // Value: the length must be between 5 and 10.
+//	value := struct {
+//	    Name  string
+//	    Value string
+//	}{"name", "demo"}
+//	err := validation.ValidateStruct(&value,
+//	    validation.Field(&a.Name, validation.Required),
+//	    validation.Field(&a.Value, validation.Required, validation.Length(5, 10)),
+//	)
+//	fmt.Println(err)
+//	// Value: the length must be between 5 and 10.
 //
 // An error will be returned if validation fails.
 func ValidateStruct(structPtr interface{}, fields ...*FieldRules) error {
@@ -109,7 +114,7 @@ func ValidateStructWithContext(ctx context.Context, structPtr interface{}, field
 					continue
 				}
 			}
-			errs[getErrorFieldName(ft)] = err
+			errs[GetErrorFieldName(ft)] = err
 		}
 	}
 


### PR DESCRIPTION
Adds an exported function GetErrorFieldName; which defaults to the existing getErrorFieldName function.  This allows a package level override of how error field names are calculated when the default isn't desired.

The test illustrates overriding this function to get the error field name from a protobuf struct tag.  