### PR TITLE
fix: skip nil entries in Errors.Error to avoid panic

### DIFF
--- a/error.go
+++ b/error.go
@@ -127,10 +127,15 @@ func (es Errors) Error() string {
 	sort.Strings(keys)
 
 	var s strings.Builder
-	for i, key := range keys {
-		if i > 0 {
+	count := 0
+	for _, key := range keys {
+		if es[key] == nil {
+			continue
+		}
+		if count > 0 {
 			s.WriteString("; ")
 		}
+		count++
 		if errs, ok := es[key].(Errors); ok {
 			_, _ = fmt.Fprintf(&s, "%v: (%v)", key, errs)
 		} else {

--- a/error_test.go
+++ b/error_test.go
@@ -35,6 +35,17 @@ func TestErrors_Error(t *testing.T) {
 	assert.Equal(t, "", errs.Error())
 }
 
+func TestErrors_ErrorNilEntry(t *testing.T) {
+	// Calling Error() must not panic when a key maps to a nil error
+	// (e.g. validation.Errors populated with a nil value before filtering).
+	errs := Errors{
+		"A": errors.New("A1"),
+		"B": nil,
+		"C": errors.New("C1"),
+	}
+	assert.Equal(t, "A: A1; C: C1.", errs.Error())
+}
+
 func TestErrors_MarshalMessage(t *testing.T) {
 	errs := Errors{
 		"A": errors.New("A1"),


### PR DESCRIPTION
Errors.Error() iterated over the sorted keys and called es[key].Error() without checking for a nil error, so an Errors map with a nil-valued key (e.g. built before Filter()) panicked with a nil pointer dereference. Skip nil entries and only insert the '; ' separator after a real entry is written. Added TestErrors_ErrorNilEntry reproducing the issue.