### PR TITLE
chore: CI modernization, golangci-lint, Codecov OIDC, documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS for go-ozzo/ozzo-validation
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything
+* @kolkov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  test:
+    name: Test - Go ${{ matrix.go-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ['1.22', '1.23']
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+
+      - name: Test
+        run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+
+      - name: Upload coverage to Codecov
+        if: matrix.go-version == '1.23'
+        uses: codecov/codecov-action@v7
+        with:
+          use_oidc: true
+          files: ./coverage.txt
+          flags: unittests
+          name: codecov-ozzo-validation
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version: '1.23'
+          cache: true
+
+      - name: Check formatting
+        run: |
+          if [ -n "$(gofmt -l .)" ]; then
+            echo "The following files are not formatted:"
+            gofmt -l .
+            exit 1
+          fi
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: latest
+          args: --timeout=5m

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,11 @@ _testmain.go
 *.test
 *.prof
 .DS_Store
+
+# AI settings
+.claude/
+.goco/
+
+# Dev docs (private)
+docs/dev/
+tmp/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,149 @@
+version: "2"
+
+run:
+  timeout: 5m
+  tests: true
+
+linters:
+  enable:
+    # Complexity
+    - gocyclo
+    - gocognit
+    - funlen
+    - nestif
+
+    # Bug detection
+    - govet
+    - staticcheck
+    - errcheck
+    - gosec
+    - nilnil
+    - nilerr
+    - ineffassign
+
+    # Style
+    - misspell
+    - whitespace
+    - unconvert
+    - unparam
+
+    # Naming
+    - revive
+
+    # Performance
+    - prealloc
+
+    # Code practices
+    - goconst
+    - gocritic
+    - goprintffuncname
+    - nolintlint
+    - nakedret
+
+    # Duplication
+    - dupl
+    - durationcheck
+
+  settings:
+    govet:
+      enable:
+        - copylocks
+      disable:
+        - fieldalignment
+
+    gocyclo:
+      min-complexity: 20
+
+    funlen:
+      lines: 120
+      statements: 60
+
+    gocognit:
+      min-complexity: 35
+
+    misspell:
+      locale: US
+
+    nestif:
+      min-complexity: 6
+
+    revive:
+      rules:
+        - name: var-naming
+        - name: error-return
+        - name: error-naming
+        - name: if-return
+        - name: increment-decrement
+        - name: var-declaration
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: indent-error-flow
+        - name: errorf
+        - name: empty-block
+        - name: superfluous-else
+        - name: unreachable-code
+        - name: redefines-builtin-id
+
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - performance
+
+      disabled-checks:
+        - commentFormatting
+        - whyNoLint
+        - unnamedResult
+        - commentedOutCode
+        - paramTypeCombine
+        - builtinShadow
+        - ifElseChain
+        - regexpSimplify
+
+      settings:
+        hugeParam:
+          sizeThreshold: 256
+
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - gocyclo
+          - funlen
+          - errcheck
+          - gosec
+          - goconst
+          - dupl
+          - gocognit
+
+      # Intentional test for unknown struct tag option
+      - path: string_test\.go
+        linters:
+          - staticcheck
+        text: "SA5008"
+
+      # Legacy public API types — cannot rename without breaking changes
+      - linters:
+          - errname
+        text: "ErrorObject|Errors|ErrFieldPointer|ErrFieldNotFound"
+
+      # Legacy pattern: nil context passed to WithContext variants
+      - linters:
+          - staticcheck
+        text: "SA1012"
+
+      # Legacy pattern: type assertions on errors (changing would break API)
+      - linters:
+          - errorlint
+        text: "type assertion on error"
+
+      # Go 1.22+ inlining suggestions for reflect constants
+      - linters:
+          - govet
+        text: "inline"
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  new: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- GitHub Actions CI with Go 1.22/1.23 matrix
+- golangci-lint integration
+- Codecov OIDC integration
+- CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md, CODEOWNERS
+
+### Fixed
+- Code formatting for Go 1.19+ doc comment style
+- Lint issues (whitespace, bool comparison, if-else chains)
+
+### Changed
+- Badges: Travis CI → GitHub Actions, Coveralls → Codecov
+
+## [4.3.0] - 2020-10-19
+
+_Last release by original author [@qiangxue](https://github.com/qiangxue)._
+
+[Unreleased]: https://github.com/go-ozzo/ozzo-validation/compare/v4.3.0...HEAD
+[4.3.0]: https://github.com/go-ozzo/ozzo-validation/releases/tag/v4.3.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,33 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a welcoming and respectful experience for everyone.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+
+Examples of unacceptable behavior:
+
+* Trolling, insulting or derogatory comments, and personal attacks
+* Public or private harassment
+* Publishing others' private information without permission
+* Other conduct which could reasonably be considered inappropriate
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported via GitHub Issues: https://github.com/go-ozzo/ozzo-validation/issues
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to ozzo-validation
+
+Thank you for your interest in contributing! This document covers how to build, test, and submit changes.
+
+## Prerequisites
+
+- **Go 1.21+** ([download](https://go.dev/dl/))
+- **golangci-lint** (`go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`)
+
+## Building
+
+```bash
+go build ./...
+```
+
+## Running Tests
+
+```bash
+go test -race ./...
+go vet ./...
+```
+
+## Code Style
+
+- Run `go fmt ./...` before every commit. CI enforces this.
+- Run `golangci-lint run --timeout=5m` and fix all issues.
+- Follow standard Go naming conventions.
+- Handle every error or explicitly ignore with `_ =` and a comment.
+- Exported types and functions must have doc comments.
+
+## Pull Request Workflow
+
+1. Fork the repository and create a feature branch:
+   ```bash
+   git checkout -b feat/my-feature
+   ```
+2. Make your changes. Keep commits focused and well-described.
+3. Verify locally:
+   ```bash
+   go fmt ./...
+   go build ./...
+   go test ./...
+   golangci-lint run --timeout=5m
+   ```
+4. Push and open a pull request against `master`.
+5. Wait for CI to pass. All checks must be green before merge.
+
+Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/):
+```
+feat: add UUID v7 validation rule
+fix: require "+" prefix in E.164 phone validation
+docs: update installation instructions
+```
+
+## Finding Work
+
+Check the [issues](https://github.com/go-ozzo/ozzo-validation/issues) page for tasks labeled [`good first issue`](https://github.com/go-ozzo/ozzo-validation/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+
+## Reporting Bugs
+
+Open an issue with a clear description, a minimal code example that reproduces the problem, and the Go version you're using.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ozzo-validation
 
+[![CI](https://github.com/go-ozzo/ozzo-validation/actions/workflows/ci.yml/badge.svg)](https://github.com/go-ozzo/ozzo-validation/actions)
+[![codecov](https://codecov.io/gh/go-ozzo/ozzo-validation/branch/master/graph/badge.svg)](https://codecov.io/gh/go-ozzo/ozzo-validation)
 [![GoDoc](https://godoc.org/github.com/go-ozzo/ozzo-validation?status.png)](http://godoc.org/github.com/go-ozzo/ozzo-validation)
-[![Build Status](https://travis-ci.org/go-ozzo/ozzo-validation.svg?branch=master)](https://travis-ci.org/go-ozzo/ozzo-validation)
-[![Coverage Status](https://coveralls.io/repos/github/go-ozzo/ozzo-validation/badge.svg?branch=master)](https://coveralls.io/github/go-ozzo/ozzo-validation?branch=master)
 [![Go Report](https://goreportcard.com/badge/github.com/go-ozzo/ozzo-validation)](https://goreportcard.com/report/github.com/go-ozzo/ozzo-validation)
 
 ## Description

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 4.3.x   | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+**DO NOT** open a public GitHub issue for security vulnerabilities.
+
+Instead, please report security issues via:
+
+1. **Private Security Advisory** (preferred):
+   https://github.com/go-ozzo/ozzo-validation/security/advisories/new
+
+2. **GitHub Issues** (for less critical issues):
+   https://github.com/go-ozzo/ozzo-validation/issues
+
+### What to Include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Affected versions
+- Potential impact
+
+### Response Timeline
+
+- **Initial Response**: Within 72 hours
+- **Fix & Disclosure**: Coordinated with reporter
+
+## Security Considerations
+
+ozzo-validation is used at input boundaries. Users should be aware of:
+
+1. **Regex Patterns** — Custom `Match()` rules with untrusted regex patterns can cause ReDoS
+2. **Error Messages** — Validation errors may contain user input; sanitize before rendering in HTML
+3. **Type Assertions** — Custom `By()` validators should handle unexpected types gracefully
+
+## Security Contact
+
+- **GitHub Security Advisory**: https://github.com/go-ozzo/ozzo-validation/security/advisories/new
+- **Public Issues**: https://github.com/go-ozzo/ozzo-validation/issues

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default:
+        target: 70%
+        threshold: 5%
+
+parsers:
+  go:
+    partials_as_hits: false
+
+comment:
+  layout: "header, diff, flags, components"
+  behavior: default
+  require_changes: false

--- a/date.go
+++ b/date.go
@@ -25,9 +25,10 @@ type DateRule struct {
 // Date returns a validation rule that checks if a string value is in a format that can be parsed into a date.
 // The format of the date should be specified as the layout parameter which accepts the same value as that for time.Parse.
 // For example,
-//    validation.Date(time.ANSIC)
-//    validation.Date("02 Jan 06 15:04 MST")
-//    validation.Date("2006-01-02")
+//
+//	validation.Date(time.ANSIC)
+//	validation.Date("02 Jan 06 15:04 MST")
+//	validation.Date("2006-01-02")
 //
 // By calling Min() and/or Max(), you can let the Date rule to check if a parsed date value is within
 // the specified date range.

--- a/is/rules.go
+++ b/is/rules.go
@@ -275,7 +275,7 @@ func isDomain(value string) bool {
 
 func isUTFNumeric(value string) bool {
 	for _, c := range value {
-		if unicode.IsNumber(c) == false {
+		if !unicode.IsNumber(c) {
 			return false
 		}
 	}

--- a/length.go
+++ b/length.go
@@ -86,17 +86,16 @@ func (r LengthRule) ErrorObject(err Error) LengthRule {
 }
 
 func buildLengthRuleError(min, max int) (err Error) {
-	if min == 0 && max > 0 {
+	switch {
+	case min == 0 && max > 0:
 		err = ErrLengthTooLong
-	} else if min > 0 && max == 0 {
+	case min > 0 && max == 0:
 		err = ErrLengthTooShort
-	} else if min > 0 && max > 0 {
-		if min == max {
-			err = ErrLengthInvalid
-		} else {
-			err = ErrLengthOutOfRange
-		}
-	} else {
+	case min > 0 && max > 0 && min == max:
+		err = ErrLengthInvalid
+	case min > 0 && max > 0:
+		err = ErrLengthOutOfRange
+	default:
 		err = ErrLengthEmptyRequired
 	}
 

--- a/map.go
+++ b/map.go
@@ -41,10 +41,11 @@ type (
 // Use Key() to specify map keys that need to be validated. Each Key() call specifies a single key which can
 // be associated with multiple rules.
 // For example,
-//    validation.Map(
-//        validation.Key("Name", validation.Required),
-//        validation.Key("Value", validation.Required, validation.Length(5, 10)),
-//    )
+//
+//	validation.Map(
+//	    validation.Key("Name", validation.Required),
+//	    validation.Key("Value", validation.Required, validation.Length(5, 10)),
+//	)
 //
 // A nil value is considered valid. Use the Required rule to make sure a map value is present.
 func Map(keys ...*KeyRules) MapRule {

--- a/minmax.go
+++ b/minmax.go
@@ -46,7 +46,6 @@ func Min(min interface{}) ThresholdRule {
 		operator:  greaterEqualThan,
 		err:       ErrMinGreaterEqualThanRequired,
 	}
-
 }
 
 // Max returns a validation rule that checks if a value is less or equal than the specified value.
@@ -64,10 +63,11 @@ func Max(max interface{}) ThresholdRule {
 
 // Exclusive sets the comparison to exclude the boundary value.
 func (r ThresholdRule) Exclusive() ThresholdRule {
-	if r.operator == greaterEqualThan {
+	switch r.operator {
+	case greaterEqualThan:
 		r.operator = greaterThan
 		r.err = ErrMinGreaterThanRequired
-	} else if r.operator == lessEqualThan {
+	case lessEqualThan:
 		r.operator = lessThan
 		r.err = ErrMaxLessThanRequired
 	}

--- a/multipleof_test.go
+++ b/multipleof_test.go
@@ -23,7 +23,6 @@ func TestMultipleOf(t *testing.T) {
 	assert.Equal(t, "must be multiple of 10", r3.Validate(uint(11)).Error())
 	assert.Equal(t, nil, r3.Validate(uint(20)))
 	assert.Equal(t, "cannot convert float32 to uint64", r3.Validate(float32(20)).Error())
-
 }
 
 func Test_MultipleOf_Error(t *testing.T) {

--- a/struct.go
+++ b/struct.go
@@ -47,16 +47,16 @@ func (e ErrFieldNotFound) Error() string {
 // should be specified as a pointer to the field. A field can be associated with multiple rules.
 // For example,
 //
-//    value := struct {
-//        Name  string
-//        Value string
-//    }{"name", "demo"}
-//    err := validation.ValidateStruct(&value,
-//        validation.Field(&a.Name, validation.Required),
-//        validation.Field(&a.Value, validation.Required, validation.Length(5, 10)),
-//    )
-//    fmt.Println(err)
-//    // Value: the length must be between 5 and 10.
+//	value := struct {
+//	    Name  string
+//	    Value string
+//	}{"name", "demo"}
+//	err := validation.ValidateStruct(&value,
+//	    validation.Field(&a.Name, validation.Required),
+//	    validation.Field(&a.Value, validation.Required, validation.Length(5, 10)),
+//	)
+//	fmt.Println(err)
+//	// Value: the length must be between 5 and 10.
 //
 // An error will be returned if validation fails.
 func ValidateStruct(structPtr interface{}, fields ...*FieldRules) error {

--- a/struct_test.go
+++ b/struct_test.go
@@ -50,11 +50,11 @@ func TestFindStructField(t *testing.T) {
 	assert.NotNil(t, findStructField(v1, reflect.ValueOf(&s1.S1)))
 	assert.NotNil(t, findStructField(v1, reflect.ValueOf(&s1.Field21)))
 	assert.NotNil(t, findStructField(v1, reflect.ValueOf(&s1.Field22)))
-	assert.NotNil(t, findStructField(v1, reflect.ValueOf(&s1.Struct2.Field22)))
+	assert.NotNil(t, findStructField(v1, reflect.ValueOf(&s1.Field22)))
 	s2 := reflect.ValueOf(&s1.Struct2).Elem()
 	assert.NotNil(t, findStructField(s2, reflect.ValueOf(&s1.Field21)))
-	assert.NotNil(t, findStructField(s2, reflect.ValueOf(&s1.Struct2.Field21)))
-	assert.NotNil(t, findStructField(s2, reflect.ValueOf(&s1.Struct2.Field22)))
+	assert.NotNil(t, findStructField(s2, reflect.ValueOf(&s1.Field21)))
+	assert.NotNil(t, findStructField(s2, reflect.ValueOf(&s1.Field22)))
 	s3 := Struct3{
 		Struct2: &Struct2{},
 	}
@@ -171,7 +171,7 @@ func TestValidateStructWithContext(t *testing.T) {
 		assertError(t, test.err, err, test.tag)
 	}
 
-	//embedded struct
+	// embedded struct
 	err := ValidateWithContext(context.Background(), &m3)
 	if assert.NotNil(t, err) {
 		assert.Equal(t, "A: error abc.", err.Error())

--- a/validation.go
+++ b/validation.go
@@ -60,11 +60,11 @@ var (
 // Validate validates the given value and returns the validation error, if any.
 //
 // Validate performs validation using the following steps:
-// 1. For each rule, call its `Validate()` to validate the value. Return if any error is found.
-// 2. If the value being validated implements `Validatable`, call the value's `Validate()`.
-//    Return with the validation result.
-// 3. If the value being validated is a map/slice/array, and the element type implements `Validatable`,
-//    for each element call the element value's `Validate()`. Return with the validation result.
+//  1. For each rule, call its `Validate()` to validate the value. Return if any error is found.
+//  2. If the value being validated implements `Validatable`, call the value's `Validate()`.
+//     Return with the validation result.
+//  3. If the value being validated is a map/slice/array, and the element type implements `Validatable`,
+//     for each element call the element value's `Validate()`. Return with the validation result.
 func Validate(value interface{}, rules ...Rule) error {
 	for _, rule := range rules {
 		if s, ok := rule.(skipRule); ok && s.skip {
@@ -103,16 +103,16 @@ func Validate(value interface{}, rules ...Rule) error {
 // ValidateWithContext validates the given value with the given context and returns the validation error, if any.
 //
 // ValidateWithContext performs validation using the following steps:
-// 1. For each rule, call its `ValidateWithContext()` to validate the value if the rule implements `RuleWithContext`.
-//    Otherwise call `Validate()` of the rule. Return if any error is found.
-// 2. If the value being validated implements `ValidatableWithContext`, call the value's `ValidateWithContext()`
-//    and return with the validation result.
-// 3. If the value being validated implements `Validatable`, call the value's `Validate()`
-//    and return with the validation result.
-// 4. If the value being validated is a map/slice/array, and the element type implements `ValidatableWithContext`,
-//    for each element call the element value's `ValidateWithContext()`. Return with the validation result.
-// 5. If the value being validated is a map/slice/array, and the element type implements `Validatable`,
-//    for each element call the element value's `Validate()`. Return with the validation result.
+//  1. For each rule, call its `ValidateWithContext()` to validate the value if the rule implements `RuleWithContext`.
+//     Otherwise call `Validate()` of the rule. Return if any error is found.
+//  2. If the value being validated implements `ValidatableWithContext`, call the value's `ValidateWithContext()`
+//     and return with the validation result.
+//  3. If the value being validated implements `Validatable`, call the value's `Validate()`
+//     and return with the validation result.
+//  4. If the value being validated is a map/slice/array, and the element type implements `ValidatableWithContext`,
+//     for each element call the element value's `ValidateWithContext()`. Return with the validation result.
+//  5. If the value being validated is a map/slice/array, and the element type implements `Validatable`,
+//     for each element call the element value's `Validate()`. Return with the validation result.
 func ValidateWithContext(ctx context.Context, value interface{}, rules ...Rule) error {
 	for _, rule := range rules {
 		if s, ok := rule.(skipRule); ok && s.skip {


### PR DESCRIPTION
## Summary

Modernize ozzo-validation CI, code quality, and documentation after 6 years of inactivity.

### CI/Infrastructure
- GitHub Actions CI replacing dead Travis CI (test matrix Go 1.22/1.23 + lint)
- Codecov integration with OIDC authentication (tokenless)
- golangci-lint v2 with enterprise config and targeted exclusions for legacy patterns
- CODEOWNERS for automatic review assignment

### Code quality
- gofmt for Go 1.19+ doc comment style (4 files)
- golangci-lint fixes: bool comparisons, if-else → switch, trailing newlines, comment formatting

### Documentation
- README badges: Travis → GitHub Actions, Coveralls → Codecov
- CHANGELOG.md (Keep a Changelog format)
- CONTRIBUTING.md (build/test/PR workflow, golangci-lint)
- CODE_OF_CONDUCT.md (Contributor Covenant 2.1)
- SECURITY.md (vulnerability reporting, validation-specific guidance)

## Test plan

- [x] `go test ./...` — PASS
- [x] `go vet ./...` — clean
- [x] `golangci-lint run` — 0 issues
- [x] `gofmt -l .` — clean
- [ ] CI workflow runs successfully on this PR
