### PR TITLE
fix: nil pointer dereference in Errors.Error() and Min/Max zero value bypass

### DIFF
--- a/error.go
+++ b/error.go
@@ -128,6 +128,9 @@ func (es Errors) Error() string {
 
 	var s strings.Builder
 	for i, key := range keys {
+		if es[key] == nil {
+			continue
+		}
 		if i > 0 {
 			s.WriteString("; ")
 		}

--- a/error_test.go
+++ b/error_test.go
@@ -33,6 +33,16 @@ func TestErrors_Error(t *testing.T) {
 
 	errs = Errors{}
 	assert.Equal(t, "", errs.Error())
+
+	// issue #147: nil value should not cause panic
+	errs = Errors{
+		"A": errors.New("A1"),
+		"B": nil,
+		"C": errors.New("C1"),
+	}
+	assert.NotPanics(t, func() {
+		_ = errs.Error()
+	})
 }
 
 func TestErrors_MarshalMessage(t *testing.T) {

--- a/minmax.go
+++ b/minmax.go
@@ -77,7 +77,7 @@ func (r ThresholdRule) Exclusive() ThresholdRule {
 // Validate checks if the given value is valid or not.
 func (r ThresholdRule) Validate(value interface{}) error {
 	value, isNil := Indirect(value)
-	if isNil || IsEmpty(value) {
+	if isNil {
 		return nil
 	}
 
@@ -119,7 +119,7 @@ func (r ThresholdRule) Validate(value interface{}) error {
 		if !ok {
 			return fmt.Errorf("cannot convert %v to time.Time", reflect.TypeOf(value))
 		}
-		if v.IsZero() || r.compareTime(t, v) {
+		if r.compareTime(t, v) {
 			return nil
 		}
 

--- a/minmax_test.go
+++ b/minmax_test.go
@@ -28,7 +28,7 @@ func TestMin(t *testing.T) {
 		{"t1.1", 1, false, 1, ""},
 		{"t1.2", 1, false, 2, ""},
 		{"t1.3", 1, false, -1, "must be no less than 1"},
-		{"t1.4", 1, false, 0, ""},
+		{"t1.4", 1, false, 0, "must be no less than 1"},
 		{"t1.5", 1, true, 1, "must be greater than 1"},
 		{"t1.6", 1, false, "1", "cannot convert string to int64"},
 		{"t1.7", "1", false, 1, "type not supported: string"},
@@ -36,25 +36,30 @@ func TestMin(t *testing.T) {
 		{"t2.1", uint(2), false, uint(2), ""},
 		{"t2.2", uint(2), false, uint(3), ""},
 		{"t2.3", uint(2), false, uint(1), "must be no less than 2"},
-		{"t2.4", uint(2), false, uint(0), ""},
+		{"t2.4", uint(2), false, uint(0), "must be no less than 2"},
 		{"t2.5", uint(2), true, uint(2), "must be greater than 2"},
 		{"t2.6", uint(2), false, "1", "cannot convert string to uint64"},
 		// float cases
 		{"t3.1", float64(2), false, float64(2), ""},
 		{"t3.2", float64(2), false, float64(3), ""},
 		{"t3.3", float64(2), false, float64(1), "must be no less than 2"},
-		{"t3.4", float64(2), false, float64(0), ""},
+		{"t3.4", float64(2), false, float64(0), "must be no less than 2"},
 		{"t3.5", float64(2), true, float64(2), "must be greater than 2"},
 		{"t3.6", float64(2), false, "1", "cannot convert string to float64"},
 		// Time cases
 		{"t4.1", date20000601, false, date20000601, ""},
 		{"t4.2", date20000601, false, date20001201, ""},
 		{"t4.3", date20000601, false, date20000101, "must be no less than 2000-06-01 00:00:00 +0000 UTC"},
-		{"t4.4", date20000601, false, date0, ""},
+		{"t4.4", date20000601, false, date0, "must be no less than 2000-06-01 00:00:00 +0000 UTC"},
 		{"t4.5", date20000601, true, date20000601, "must be greater than 2000-06-01 00:00:00 +0000 UTC"},
 		{"t4.6", date20000601, true, 1, "cannot convert int to time.Time"},
 		{"t4.7", struct{}{}, false, 1, "type not supported: struct {}"},
 		{"t4.8", date0, false, date20000601, ""},
+		// Zero value tests (issue #165)
+		{"t5.1", 0, false, 0, ""},
+		{"t5.2", 0, true, 0, "must be greater than 0"},
+		{"t5.3", float64(0), true, float64(0), "must be greater than 0"},
+		{"t5.4", 1, false, 0, "must be no less than 1"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Summary

Two bug fixes for v4.4.0:

### 1. Errors.Error() nil pointer dereference (#147)
`Errors.Error()` panicked when the map contained nil values. Added nil check to skip nil entries.

### 2. Min/Max silently passes zero values (#165, #180)
`Min()` and `Max()` treated zero values (int 0, float 0.0, time.Time{}) as "empty" and skipped validation entirely. Zero is a legitimate value that should be compared against the threshold.

**Behavior change:** `Min(1).Validate(0)` now correctly returns an error instead of silently passing.

## Test plan

- [x] Added test for nil Errors.Error() (no panic)
- [x] Updated Min/Max tests for zero values
- [x] Added specific tests for Min(0).Exclusive() (#165)
- [x] All existing tests pass
- [x] golangci-lint: 0 issues

Fixes #147. Fixes #165. Fixes #180.