### PR TITLE
chore: add enterprise-level benchmark infrastructure

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,53 @@
+name: Benchmark
+
+# Historical Benchmark Tracking:
+# - Runs on push to master (track performance over time)
+# - Stores results on gh-pages branch for visualization
+# - Alerts on >150% regression (comment on commit, no CI failure)
+# - View results: https://go-ozzo.github.io/ozzo-validation/dev/bench/
+
+on:
+  push:
+    branches: [master]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  benchmark:
+    name: Benchmark
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+
+    - name: Set up Go
+      uses: actions/setup-go@v7
+      with:
+        go-version: '1.23'
+        cache: true
+
+    - name: Run benchmarks
+      run: |
+        go test -bench=. -benchmem -run=^$ ./... > benchmark_results.txt
+        cat benchmark_results.txt
+
+    - name: Store benchmark result
+      uses: benchmark-action/github-action-benchmark@v1
+      continue-on-error: true
+      if: github.ref == 'refs/heads/master'
+      with:
+        tool: 'go'
+        output-file-path: benchmark_results.txt
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        auto-push: true
+        alert-threshold: '150%'
+        comment-on-alert: true
+        fail-on-alert: false
+        benchmark-data-dir-path: dev/bench

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v7
       with:
-        go-version: '1.23'
+        go-version: '1.25'
         cache: true
 
     - name: Run benchmarks

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v7
       with:
-        go-version: '1.23'
+        go-version: '1.25'
         cache: false
 
     - name: Install benchstat

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,127 @@
+name: Benchmark Comparison
+
+# Benchmark Comparison Strategy:
+# - Runs on PRs to master (detect performance regressions)
+# - Compares PR benchmarks with base branch using benchstat
+# - Posts results as PR comment (informational, not blocking)
+# - Uses 5 iterations for reasonable CI time vs statistical significance
+#
+# Note: GitHub Actions shared runners have ~10-20% variance.
+# Results are directional, not absolute. Major regressions (>30%) are reliable.
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  benchmark-compare:
+    name: Benchmark Comparison
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+
+    steps:
+    - name: Checkout PR branch
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        path: pr
+
+    - name: Checkout base branch
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ github.event.pull_request.base.sha }}
+        path: base
+
+    - name: Set up Go
+      uses: actions/setup-go@v7
+      with:
+        go-version: '1.23'
+        cache: false
+
+    - name: Install benchstat
+      run: go install golang.org/x/perf/cmd/benchstat@latest
+
+    - name: Run base branch benchmarks
+      working-directory: base
+      run: |
+        echo "# Base branch benchmarks - ${{ github.event.pull_request.base.sha }}" > ../base-bench.txt
+        echo "# Generated: $(date -Iseconds)" >> ../base-bench.txt
+        echo "" >> ../base-bench.txt
+        go test -bench=. -benchmem -count=5 -benchtime=100ms -run=^$ ./... 2>/dev/null >> ../base-bench.txt || true
+
+    - name: Run PR branch benchmarks
+      working-directory: pr
+      run: |
+        echo "# PR branch benchmarks - ${{ github.event.pull_request.head.sha }}" > ../pr-bench.txt
+        echo "# Generated: $(date -Iseconds)" >> ../pr-bench.txt
+        echo "" >> ../pr-bench.txt
+        go test -bench=. -benchmem -count=5 -benchtime=100ms -run=^$ ./... 2>/dev/null >> ../pr-bench.txt || true
+
+    - name: Compare benchmarks
+      id: benchstat
+      run: |
+        benchstat base-bench.txt pr-bench.txt > full-comparison.txt 2>&1 || echo "benchstat comparison failed" > full-comparison.txt
+
+        GEOMEAN=$(grep -E "^geomean" full-comparison.txt | head -1 || echo "")
+        REGRESSIONS=$(grep -E "\+[0-9]+\.[0-9]+%" full-comparison.txt | grep -v "~" | head -10 || echo "")
+
+        echo "## Benchmark Comparison" > comparison.md
+        echo "" >> comparison.md
+        echo "Comparing \`${{ github.event.pull_request.base.ref }}\` → PR #${{ github.event.pull_request.number }}" >> comparison.md
+        echo "" >> comparison.md
+
+        if [ -n "$GEOMEAN" ]; then
+          echo "**Summary:** \`$GEOMEAN\`" >> comparison.md
+          echo "" >> comparison.md
+        fi
+
+        if [ -n "$REGRESSIONS" ]; then
+          echo "⚠️ **Potential regressions detected:**" >> comparison.md
+          echo "\`\`\`" >> comparison.md
+          echo "$REGRESSIONS" >> comparison.md
+          echo "\`\`\`" >> comparison.md
+          echo "" >> comparison.md
+        else
+          echo "✅ No significant regressions detected." >> comparison.md
+          echo "" >> comparison.md
+        fi
+
+        echo "> Full results available in workflow artifacts. CI runners have ~10-20% variance." >> comparison.md
+
+        cat comparison.md
+
+    - name: Upload benchmark results
+      uses: actions/upload-artifact@v7
+      with:
+        name: benchmark-comparison
+        path: |
+          base-bench.txt
+          pr-bench.txt
+          full-comparison.txt
+        retention-days: 30
+
+    - name: Find existing comment
+      uses: peter-evans/find-comment@v4
+      id: fc
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'github-actions[bot]'
+        body-includes: '## Benchmark Comparison'
+
+    - name: Create or update comment
+      uses: peter-evans/create-or-update-comment@v5
+      with:
+        comment-id: ${{ steps.fc.outputs.comment-id }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body-path: comparison.md
+        edit-mode: replace

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,147 @@
+package validation
+
+import (
+	"context"
+	"regexp"
+	"testing"
+)
+
+type benchStruct struct {
+	Name   string
+	Email  string
+	Age    int
+	Street string
+	City   string
+	Zip    string
+}
+
+func BenchmarkValidateStruct(b *testing.B) {
+	s := benchStruct{
+		Name:   "John Doe",
+		Email:  "john@example.com",
+		Age:    30,
+		Street: "123 Main St",
+		City:   "Springfield",
+		Zip:    "12345",
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ValidateStruct(&s,
+			Field(&s.Name, Required, Length(1, 100)),
+			Field(&s.Email, Required, Length(5, 255)),
+			Field(&s.Age, Required, Min(1), Max(150)),
+			Field(&s.Street, Required, Length(1, 200)),
+			Field(&s.City, Required, Length(1, 100)),
+			Field(&s.Zip, Required, Match(regexp.MustCompile(`^\d{5}$`))),
+		)
+	}
+}
+
+func BenchmarkValidateStruct_Invalid(b *testing.B) {
+	s := benchStruct{}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ValidateStruct(&s,
+			Field(&s.Name, Required, Length(1, 100)),
+			Field(&s.Email, Required, Length(5, 255)),
+			Field(&s.Age, Required, Min(1), Max(150)),
+			Field(&s.Street, Required, Length(1, 200)),
+			Field(&s.City, Required, Length(1, 100)),
+			Field(&s.Zip, Required, Length(5, 10)),
+		)
+	}
+}
+
+func BenchmarkValidateStructWithContext(b *testing.B) {
+	ctx := context.Background()
+	s := benchStruct{
+		Name:   "John Doe",
+		Email:  "john@example.com",
+		Age:    30,
+		Street: "123 Main St",
+		City:   "Springfield",
+		Zip:    "12345",
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ValidateStructWithContext(ctx, &s,
+			Field(&s.Name, Required, Length(1, 100)),
+			Field(&s.Email, Required, Length(5, 255)),
+			Field(&s.Age, Required, Min(1), Max(150)),
+			Field(&s.Street, Required, Length(1, 200)),
+			Field(&s.City, Required, Length(1, 100)),
+			Field(&s.Zip, Required, Length(5, 10)),
+		)
+	}
+}
+
+func BenchmarkValidateMap(b *testing.B) {
+	m := map[string]interface{}{
+		"name":  "John Doe",
+		"email": "john@example.com",
+		"age":   30,
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		Validate(m,
+			Map(
+				Key("name", Required, Length(1, 100)),
+				Key("email", Required, Length(5, 255)),
+				Key("age", Required, Min(1)),
+			),
+		)
+	}
+}
+
+func BenchmarkValidateSimpleValue(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		Validate("test@example.com", Required, Length(5, 255))
+	}
+}
+
+func BenchmarkValidateWithConditional(b *testing.B) {
+	s := benchStruct{
+		Name:  "John",
+		Email: "john@example.com",
+		Age:   30,
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ValidateStruct(&s,
+			Field(&s.Name, Required),
+			Field(&s.Email, When(s.Name != "", Required, Length(5, 255))),
+			Field(&s.Age, When(s.Age > 0, Min(1), Max(150))),
+		)
+	}
+}
+
+func BenchmarkEach_100Items(b *testing.B) {
+	items := make([]string, 100)
+	for i := range items {
+		items[i] = "value"
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		Validate(items, Each(Required, Length(1, 50)))
+	}
+}
+
+func BenchmarkEachUntilFirstError_100Items(b *testing.B) {
+	items := make([]string, 100)
+	items[0] = ""
+	for i := 1; i < len(items); i++ {
+		items[i] = "value"
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		Validate(items, EachUntilFirstError(Required))
+	}
+}


### PR DESCRIPTION
## Summary

Enterprise-level benchmark infrastructure for tracking and preventing performance regressions.

### PR Comparison (benchmarks.yml)
- Runs on every PR to master
- Compares base vs PR using `benchstat`
- Posts regression summary as PR comment
- Uploads raw results as artifacts (30-day retention)

### Historical Tracking (benchmark.yml)
- Runs on push to master
- Stores results on gh-pages via `github-action-benchmark`
- Alerts on >150% regression
- Visualization at https://go-ozzo.github.io/ozzo-validation/dev/bench/

### Benchmarks (benchmark_test.go)
8 benchmarks covering all validation paths:
- ValidateStruct (valid/invalid, 6 fields)
- ValidateStructWithContext
- ValidateMap
- ValidateSimpleValue
- ValidateWithConditional (When rules)
- Each (100 items)
- EachUntilFirstError (100 items)

## Test plan
- [x] All benchmarks run successfully
- [x] `go test ./...` passes
- [x] golangci-lint: 0 issues