### PR TITLE
fix: pre-compile regex in benchmark

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -15,6 +15,8 @@ type benchStruct struct {
 	Zip    string
 }
 
+var benchZipRegex = regexp.MustCompile(`^\d{5}$`)
+
 func BenchmarkValidateStruct(b *testing.B) {
 	s := benchStruct{
 		Name:   "John Doe",
@@ -33,7 +35,7 @@ func BenchmarkValidateStruct(b *testing.B) {
 			Field(&s.Age, Required, Min(1), Max(150)),
 			Field(&s.Street, Required, Length(1, 200)),
 			Field(&s.City, Required, Length(1, 100)),
-			Field(&s.Zip, Required, Match(regexp.MustCompile(`^\d{5}$`))),
+			Field(&s.Zip, Required, Match(benchZipRegex)),
 		)
 	}
 }


### PR DESCRIPTION
Pre-compile regex in BenchmarkValidateStruct to measure actual library allocations.

`regexp.MustCompile` was called inside the benchmark loop, adding ~47 allocations per iteration.

**Before:** 106 allocs/op (inflated by regex compilation)
**After:** 59 allocs/op (true library allocations)

This establishes the correct baseline for performance optimization work.